### PR TITLE
Update guava version to latest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     compile group: 'com.github.rvesse', name: 'airline', version: '2.2.0'
 	
     compile group: 'org.antlr', name: 'antlr-runtime', version:'3.2'
-    compile group: 'com.google.guava', name: 'guava', version:'14.0.1'
+    compile group: 'com.google.guava', name: 'guava', version:'27.1-jre'
     compile group: 'colt', name: 'colt', version:'1.2.0'
     compile group: 'commons-codec', name: 'commons-codec', version:'1.7'
     compile group: 'org.apache.commons', name: 'commons-collections4', version:'4.0'


### PR DESCRIPTION
com.google.common.base.Stopwatch.createUnstarted() was only added in
Guava version 15.0, but the old version in build.gradle was 14.0.1